### PR TITLE
Suppress `warning: BigDecimal.new is deprecated`

### DIFF
--- a/lib/analyzer/rss.rb
+++ b/lib/analyzer/rss.rb
@@ -39,7 +39,7 @@ class Analyzer
     # Pull memory from `ps` command, takes more resources and can freeze
     # in low memory situations
     def ps_memory
-      KB_TO_BYTE * BigDecimal.new(`ps -o rss= -p #{@pid}`)
+      KB_TO_BYTE * BigDecimal(`ps -o rss= -p #{@pid}`)
     end
   
   end


### PR DESCRIPTION
It's deprecated in ruby 2.6
https://github.com/ruby/bigdecimal/commit/533737338db915b00dc7168c3602e4b462b23503

Similar change in rails:
https://github.com/rails/rails/commit/6c6c3fa166975e5aebbe444605d736909e9eb75b